### PR TITLE
Accept dns_opt resolv.conf options

### DIFF
--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -274,7 +274,7 @@ on (by name). Additionally, each instance may define:
 - ``dns``, to specify one (as a single IP address) or more DNS servers (as a
   list) to be declared inside the container;
 
-- ``dns-opt``, to specify the options used by DNS resolvers by writing
+- ``dns_opt``, to specify the options used by DNS resolvers by writing
   an options line into the container's /etc/resolv.conf. See documentation
   for resolv.conf for a list of valid options;
 

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -274,6 +274,10 @@ on (by name). Additionally, each instance may define:
 - ``dns``, to specify one (as a single IP address) or more DNS servers (as a
   list) to be declared inside the container;
 
+- ``dns-opt``, to specify the options used by DNS resolvers by writing
+  an options line into the container's /etc/resolv.conf. See documentation
+  for resolv.conf for a list of valid options;
+
 - ``security_opt``, to specify additional security options to customize
   container labels, apparmor profiles, etc.
 
@@ -329,6 +333,7 @@ For example:
             swap: 200m
             cpu: 10
           dns: [ 8.8.8.8, 8.8.4.4 ]
+          dns_opt: [ 'timeout:10', 'attempts:2' ]
           net: host
           restart:
             name: on-failure

--- a/maestro/entities.py
+++ b/maestro/entities.py
@@ -429,6 +429,11 @@ class Container(Entity):
         if isinstance(self.dns, six.string_types):
             self.dns = [self.dns]
 
+        # DNS Options for resolve.conf, always as a list
+        self.dns_opt = config.get('dns_opt')
+        if isinstance(self.dns_opt, six.string_types):
+            self.dns_opt = [self.dns_opt]
+
         # Stop timeout
         self.stop_timeout = config.get('stop_timeout', 10)
 
@@ -479,6 +484,7 @@ class Container(Entity):
             network_mode=self.network_mode,
             restart_policy=self.restart_policy,
             dns=self.dns,
+            dns_opt=self.dns_opt,
             links=self.links,
             ulimits=self.ulimits,
             volumes_from=list(self.volumes_from),

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -70,7 +70,7 @@ class ContainerTest(unittest.TestCase):
     SHIP = 'ship'
     SHIP_IP = '10.0.0.1'
     SCHEMA = {'schema': 2}
-    DOCKER_VERSION = '1.12'
+    DOCKER_VERSION = '1.21'
     PORTS = {'server': 4848}
 
     def _cntr(service_name=SERVICE, service_env=None, image=IMAGE,
@@ -139,6 +139,17 @@ class ContainerTest(unittest.TestCase):
 
     def test_no_dns_option(self):
         self.assertIsNone(self._cntr().dns)
+
+    def test_dns_opt_option(self):
+        container = self._cntr(config={'dns_opt': 'attempts:2'})
+        self.assertEqual(container.dns_opt, ['attempts:2'])
+
+    def test_dns_opt_as_list_option(self):
+        container = self._cntr(config={'dns_opt': ['timeout:10', 'attempts:2']})
+        self.assertEqual(container.dns_opt, ['timeout:10', 'attempts:2'])
+
+    def test_no_dns_opt_option(self):
+        self.assertIsNone(self._cntr().dns_opt)
 
     def test_swap_limit_number(self):
         container = self._cntr(config={'limits': {'swap': 42}})


### PR DESCRIPTION
Pass through dns_opt resolv.conf options to docker-py

Docker API version 1.21 and above is required for `dns_opt`